### PR TITLE
Specification typo: Wrong signing key in Sig02 calculation

### DIFF
--- a/files/spec/salt-channel-v2-final2.md
+++ b/files/spec/salt-channel-v2-final2.md
@@ -895,14 +895,14 @@ Challenge02:
  
  
 Client side:
-    Challenge01 = { "SC-SIG02" || SHA512(M1) || SHA512(M2) }
-    Sig02 = sign(Challenge02, ServerSigSec)
- 
+    Challenge02 = { "SC-SIG02" || SHA512(M1) || SHA512(M2) }
+    Sig02 = sign(Challenge02, ClientSigSec)
+
 Server side:
-    Challenge01 = { "SC-SIG02" || SHA512(M1) || SHA512(M2) }
-    verify(Sig02, Challenge02, ServerSigPub)
- 
- 
+    Challenge02 = { "SC-SIG02" || SHA512(M1) || SHA512(M2) }
+    verify(Sig02, Challenge02, ClientSigPub)
+
+
 ---------------------------------------------------------
 | ASCII for "SC-SIG02"                                  |
 ---------------------------------------------------------


### PR DESCRIPTION
The wrong signing key seems to be used in the calculation for Sig02 in the latest version of the spec. The client's signature is created with the server's private signature key. Furthermore, the server is verifying the signature with the public server signing key. 

Also the wrong challenge denotation (Chellange01 instead of Challenge02).